### PR TITLE
allow to set widget / version tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .bitrise*
 .gows.user.yml
 node_modules
+_tmp/
+s

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,7 +40,14 @@ workflows:
           file if you would not specify another value.
         run_if: true
         inputs:
-        - example_step_input: Example Step Input's value
+        - name:
+        - id:
+        - version: "0.9.0"
+        - android_version_code:
+        - android_package_name:
+        - ios_bundle_version:
+        - ios_bundle_identifier:
+        - config_path: ./config.xml
     - script:
         inputs:
         - content: |

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const CONFIG_FILE_PATH = process.env['config_path'] || 'config.xml'
 
 const NAME = process.env['name'];
 const ID = process.env['id'];
+const VERSION = process.env['version'];
 
 const ANDROID_VERSION_CODE = process.env['android_version_code'];
 const ANDROID_PACKAGE_NAME = process.env['android_package_name'];
@@ -17,16 +18,22 @@ const IOS_BUNDLE_IDENTIFIER = process.env['ios_bundle_identifier'];
 // Load and parse the config.xml
 const config = new Config(path.join(SOURCE_PATH, CONFIG_FILE_PATH));
 
-if(NAME) {
+if (NAME) {
   config.setName(NAME);
 
   log('name', NAME);
 }
 
-if(ID) {
+if (ID) {
   config.setID(ID);
 
   log('id', ID);
+}
+
+if (VERSION) {
+  config.setVersion(VERSION);
+
+  log('version', VERSION);
 }
 
 if (ANDROID_VERSION_CODE) {

--- a/step.yml
+++ b/step.yml
@@ -63,6 +63,12 @@ inputs:
       summary: Modify the attribute `id` the config.xml file
       is_expand: true
       is_required: false
+  - version: $CORDOVA_VERSION
+    opts:
+      title: Cordova version
+      summary: Modify the attribute `version` the config.xml file
+      is_expand: true
+      is_required: false
   - android_version_code: $CORDOVA_ANDROID_VERSION_CODE
     opts:
       title: Android version code


### PR DESCRIPTION
This PR introduces a new input: `version`, which allows users to set the widget / version property of the config.xml file.
Other then that a small update also introduced in the bitrise.yml, if you put a config.xml file in the _tmp dir you can play with the step during development.